### PR TITLE
Fix Markdown in documentation

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -1,4 +1,6 @@
-TUBSy uses Grunt [0] for automating mundane tasks.
+TUBSy uses [Grunt][] for automating mundane tasks.
+
+  [Grunt]: http://gruntjs.com
 
 Prerequisite: Node Package Manager (npm)
 
@@ -10,5 +12,3 @@ Run Grunt: `grunt`
 You should get a minimized version of tubsy.js that's called tubsy.min.js.
 
 Note! In Debian based systems, you might need to do this: `ln -s /usr/bin/nodejs /usr/bin/node`
-
-[0] http://gruntjs.com

--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 TUBSy is a JavaScript library for generating TUBS scores.
 
 # TUBS WTF?!
-Time Unit Box System (TUBS) is a notation for events in time.
+[Time Unit Box System][TUBS] (TUBS) is a notation for events in time.
 It's used often for notating rhythm music.
 
-https://en.wikipedia.org/wiki/Time_unit_box_system
+  [TUBS]: https://en.wikipedia.org/wiki/Time_unit_box_system
 
 # Enough! Just show me.
 A nice malinke rhythm for circumcision, slow Soli, for djembe could look like this in TUBS:


### PR DESCRIPTION
Use proper [Markdown syntax](http://daringfireball.net/projects/markdown/syntax) for links.